### PR TITLE
Links Externos adicionados

### DIFF
--- a/source/pyconamazonia2017.rst
+++ b/source/pyconamazonia2017.rst
@@ -43,3 +43,10 @@ Conclusões
    :maxdepth: 2
 
    2017/conclusoes
+
+Links externos
+------------------------
+
+`Fotos Oficiais <http://www.flickr.com/photos/jcemelanda/sets/72157685381999944>`_
+
+`Site <http://amazonia.python.org.br/>`_


### PR DESCRIPTION
Foi adicionado a parte para Links externos com o endereço das Fotos Oficiais e do Site do evento.